### PR TITLE
Fixes "render-props" link to point to #render-prop

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -271,7 +271,7 @@ This pattern can be combined with destructuring, JSX Spread Attributes, and othe
 ## Function as children
 
 React components don't support functions as `children`.
-However, [render props](#render-props) is a pattern for creating components that take functions as children.
+However, [render props](#render-prop) is a pattern for creating components that take functions as children.
 
 ## Render prop
 


### PR DESCRIPTION
I think an alternative approach could be to change the title (line 276) of the heading to which this link refers to: `## Render props` and leave the link as is. 