### PR TITLE
add short-circuit evaluation as suggestion to falsy classnames

### DIFF
--- a/reactpatterns.com/pages/index.md
+++ b/reactpatterns.com/pages/index.md
@@ -198,16 +198,19 @@ function MyButton({ className, ...props }) {
 }
 ```
 
-To guard from [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) values showing up as a className,
-use [short-circuit evaluation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Short-circuit_evaluation)
+To guard from `undefined` showing up as a className, you could update your logic to filter out `falsy` values:
 
 ```jsx
 function MyButton({ className, ...props }) {
-  let classNames = ["btn", className || ""].join(" ");
+  let classNames = ["btn", className].filter(Boolean).join(" ").trim();
 
   return <button className={classNames} {...props} />;
 }
 ```
+
+Bear in mind though that if an empty object is passed it'll be included in the class as well, resulting in: `btn [object Object]`.
+
+The better approach is to make use of available packages, like [classnames](https://www.npmjs.com/package/classnames) or [clsx](https://www.npmjs.com/package/clsx), that could be used to join classnames, relieving you from having to deal with it manually.
 
 ## Conditional rendering
 

--- a/reactpatterns.com/pages/index.md
+++ b/reactpatterns.com/pages/index.md
@@ -198,12 +198,12 @@ function MyButton({ className, ...props }) {
 }
 ```
 
-To guard from `undefined` showing up as a className,  
-Use [default values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#Default_values_2).
+To guard from [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) values showing up as a className,
+use [short-circuit evaluation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Short-circuit_evaluation)
 
 ```jsx
-function MyButton({ className = "", ...props }) {
-  let classNames = ["btn", className].join(" ");
+function MyButton({ className, ...props }) {
+  let classNames = ["btn", className || ""].join(" ");
 
   return <button className={classNames} {...props} />;
 }


### PR DESCRIPTION
Unfortunately, setting a default value will not protect against all the falsy values:

```js
const falsyValues = [false, null, undefined, 0, NaN, ""];

function MyButton({ className = "", ...props }) {
  let classNames = ["btn", className].join(" ");

  return <button className={classNames}>Delete</button>
}

function App() {
  return (
    <>
      {falsyValues.map(value => (
         <MyButton key={Math.random()} className={value}>
           Delete
         </MyButton>
      }
    </>
  )
}
```

Results in:
```html
<div id="root">
  <button class="btn false">Delete</button>
  <button class="btn ">Delete</button>
  <button class="btn ">Delete</button>
  <button class="btn 0">Delete</button>
  <button class="btn NaN">Delete</button>
  <button class="btn ">Delete</button>
</div>
```

Even though cases such as having `0` and `NaN` in the className prop are oddly, having `false` appears to be a mistake that could happen.

Using short-circuit evaluation fixes these cases:
```js
function MyButton({ className, ...props }) {
  let classNames = ["btn", className || ""].join(" ");

  return <button className={classNames}>Delete</button>
}
```
