### PR TITLE
Add Yamline to a-non-comprehensive-guide-to-yaml

### DIFF
--- a/chan.dev/src/content/posts/a-non-comprehensive-guide-to-yaml-for-folks-who-like-json-just-fine.md
+++ b/chan.dev/src/content/posts/a-non-comprehensive-guide-to-yaml-for-folks-who-like-json-just-fine.md
@@ -332,6 +332,7 @@ https://stackoverflow.com/a/21699210
   - https://jsonformatter.org/yaml-to-json
   - https://onlineyamltools.com/convert-yaml-to-json
   - https://stackoverflow.com/a/21699210/754775
+  - https://yamline.com/json/
 
 ## Keep in touch
 


### PR DESCRIPTION
Add Yamline (my website), an online YAML toolbox, to "Resources and further reading" in a-non-comprehensive-guide-to-yaml-for-folks-who-like-json-just-fine.md